### PR TITLE
Add naive implementation of remctl_set_timeout

### DIFF
--- a/client/remctl.go
+++ b/client/remctl.go
@@ -227,6 +227,18 @@ func (r *remctl) Setccache( ccache string ) ( error ) {
     return nil
 }
 
+// SetTimeout allows you to set the network timeout in seconds, which may be
+// 0 to not use any timeout (the default).
+func (r *remctl) SetTimeout(timeout uint) error {
+	timeout_c := C.long(timeout)
+
+	if set := C.remctl_set_timeout(r.ctx, timeout_c); set != 1 {
+		return r.get_error()
+	}
+
+	return nil
+}
+
 // Close() the remctl connection after you are done with it
 // 
 // After calling, the struct is useless and should be deleted

--- a/example/complex.go
+++ b/example/complex.go
@@ -21,8 +21,10 @@ func main() {
 
     var host, princ string
     var port uint16
+    var timeout uint
 
     flag.StringVar( &princ, "s", "", "remctl service principal (default host/<hostname>)" )
+    flag.UintVar(&timeout, "t", 0, "timeout in seconds. Defaults to zero")
     flag.Parse()
 
     args := flag.Args()
@@ -57,6 +59,13 @@ func main() {
 	fmt.Println( err )
 	os.Exit( 1 )
     }
+
+	if timeout > 0 {
+		if err := remc.SetTimeout(timeout); err != nil {
+			fmt.Println(err)
+			os.Exit(1)
+		}
+	}
 
     if err := remc.Open( host, port, princ ); err != nil {
 	fmt.Println( err )


### PR DESCRIPTION
Basic implementation, maybe not really at the state of the art of what we can do in Go, but it works.

Example `complex.go` have been updated to show how to use the `SetTimeout()` method.